### PR TITLE
chore: fixes php requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=7.2.5",
+        "php": "^8.0",
         "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0",
         "symfony/process": "^4.4.21 || ^5.2.4"
     },


### PR DESCRIPTION
This pull requests makes PHP 8 required in this library - as it using PHP 8 code on the `src` directory: `str_starts_with`, etc.