### PR TITLE
feat: removes Laravel 5 from the list of support Laravel versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0",
+        "illuminate/support": "^6.0 || ^7.0 || ^8.0",
         "symfony/process": "^4.4.21 || ^5.2.4"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel 5 doesn't support PHP 8, so it can be removed from the list.