### PR TITLE
Add symfony/process back to `require` and update dev dependencies

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         php: [8.2, 8.3, 8.4]
+        composer-deps: [lowest, highest]
 
     steps:
     - uses: actions/checkout@v4
@@ -25,16 +26,10 @@ jobs:
     - name: Validate composer.json
       run: composer validate --strict
 
-    - name: Cache Composer packages
-      uses: actions/cache@v4
+    - name: Install Composer dependencies
+      uses: ramsey/composer-install@v3
       with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-${{ matrix.php }}-
-
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress
+        dependency-versions: ${{ matrix.composer-deps }}
 
     - name: Run tests
       run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,15 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^8.2"
+        "php": "^8.2",
+        "symfony/process": "^6.0|^7.0"
     },
     "require-dev": {
-        "laravel/framework": "^9.0|^10.0|^11.0|^12.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
-        "phpunit/phpunit": "^11|^12",
+        "laravel/framework": "^10.0|^11.0|^12.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "phpunit/phpunit": "^10|^11|^12",
         "guzzlehttp/guzzle": "^7.5",
-        "pestphp/pest": "^3.7"
+        "pestphp/pest": "^2.0|^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds symfony/process back to the `require` block. It was removed in c267e74830868aff5beb3ecc9db5a6711ac4e28b, but it's still used in Ciareis\Bypass:

https://github.com/ciareis/bypass/blob/c267e74830868aff5beb3ecc9db5a6711ac4e28b/src/Bypass.php#L92

The tests still pass because some of the dev dependencies require symfony/process, but since you can't guarantee that other users of Bypass will also require symfony/process, it should be included in `require`.

---

The wide range of dependency versions listed in `composer.json` is impossible to resolve to the lowest version of dependencies.

When I'm on PHP 8.2, and I run the following:

``` shell
composer update --prefer-lowest
```

The lowest versions it installs are:

```
❯ composer info --direct
guzzlehttp/guzzle   7.8.0   Guzzle is a PHP HTTP client library
laravel/framework   11.33.2 The Laravel Framework.
orchestra/testbench 9.0.0   Laravel Testing Helper for Packages Development
pestphp/pest        3.7.0   The elegant PHP Testing Framework.
phpunit/phpunit     11.5.0  The PHP Unit Testing framework.
symfony/process     7.2.0   Executes commands in sub-processes
```

Here are some of the reasons it can't go lower:

1. orchestra/testbench v7 requires `"phpunit/phpunit": "^9.5.10"`, which evaluates to `>=9.5.10 <10.0.0`, and since Bypass requires `"phpunit/phpunit": "^11|^12"`, Composer can't install orchestra/testbench v7.
2. Similarly, orchestra/testbench v8 requires `"phpunit/phpunit": "^9.6 || ^10.0.7"`, which evaluates to `>=9.6.0 <10.0.0 || >=10.0.7 <11.0.0`, so it also cannot be satisfied.
3. You could solve this by setting phpunit/phpunit to require `^9.5|^10|^11|^12`, but since pestphp/pest is set to `^3.7`, and v3.7.0 requires PHPUnit v11.5, it still won't resolve to a lower version of PHPUnit, and thus it can't resolve to a lower version of orchestra/testbench. To do so, you'll need to require Pest v2 or lower.

If the goal is to support symfony/process v6 and v7, then I recommend allowing at least PHPUnit v10 and Pest v2 and dropping laravel/framework v9 and orchestra/testbench v7 from your dependencies, since they can never be resolved using `--prefer-lowest` (without a lot of work).

With the changes in this PR, we can now get to the following as the lowest versions of dependencies, which includes symfony/process v6.2.7:

```
❯ composer info --direct
guzzlehttp/guzzle   7.5.0   Guzzle is a PHP HTTP client library
laravel/framework   10.0.0  The Laravel Framework.
orchestra/testbench 8.0.0   Laravel Testing Helper for Packages Development
pestphp/pest        2.0.1   An elegant PHP Testing Framework.
phpunit/phpunit     10.0.16 The PHP Unit Testing framework.
symfony/process     6.2.7   Executes commands in sub-processes
```

And `./vendor/bin/pest` still passes with these dependencies!

I've updated the GitHub Action so that it runs tests against the lowest and highest versions of the dependencies. I hope it's okay that I used [my own composer-install GitHub Action](https://github.com/ramsey/composer-install) for this; it was the easiest way to get it working. (It automatically does the dependency caching, so you don't need an extra step for that.)

